### PR TITLE
Correction of the owner of the data type of the expression

### DIFF
--- a/include/core/lily/checked/data_type.h
+++ b/include/core/lily/checked/data_type.h
@@ -334,6 +334,7 @@ struct LilyCheckedDataType
 {
     enum LilyCheckedDataTypeKind kind;
     const Location *location; // const Location*? (&)
+    Usize ref_count;
     union
     {
         LilyCheckedDataTypeArray array;
@@ -704,6 +705,18 @@ is_compiler_defined__LilyCheckedDataType(LilyCheckedDataType *self)
            self->kind == LILY_CHECKED_DATA_TYPE_KIND_COMPILER_CHOICE ||
            self->kind == LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC ||
            self->kind == LILY_CHECKED_DATA_TYPE_KIND_UNKNOWN;
+}
+
+/**
+ *
+ * @brief Pass to ref a data type and increment the `ref_count`.
+ * @return LilyCheckedDataType* (&)
+ */
+inline LilyCheckedDataType *
+ref__LilyCheckedDataType(LilyCheckedDataType *self)
+{
+    ++self->ref_count;
+    return self;
 }
 
 /**

--- a/include/core/lily/checked/data_type.h
+++ b/include/core/lily/checked/data_type.h
@@ -694,6 +694,20 @@ is_compiler_defined_and_known_dt__LilyCheckedDataType(LilyCheckedDataType *self)
 
 /**
  *
+ * @brief Check if is a compiler defined data type.
+ */
+inline bool
+is_compiler_defined__LilyCheckedDataType(LilyCheckedDataType *self)
+{
+    return self->kind ==
+             LILY_CHECKED_DATA_TYPE_KIND_CONDITIONAL_COMPILER_CHOICE ||
+           self->kind == LILY_CHECKED_DATA_TYPE_KIND_COMPILER_CHOICE ||
+           self->kind == LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC ||
+           self->kind == LILY_CHECKED_DATA_TYPE_KIND_UNKNOWN;
+}
+
+/**
+ *
  * @brief Free LilyCheckedDataType.
  */
 DESTRUCTOR(LilyCheckedDataType, LilyCheckedDataType *self);

--- a/include/core/lily/checked/expr.h
+++ b/include/core/lily/checked/expr.h
@@ -61,8 +61,12 @@ typedef struct LilyCheckedExpr
 {
     enum LilyCheckedExprKind kind;
     const Location *location; // const Location* (&)
-    LilyCheckedDataType
-      *data_type; // This is the result data type of the expression.
+                              // This is the result data type of the expression.
+    LilyCheckedDataType *
+      data_type; // LilyCheckedDataType* (&)
+                 // when is equal to LILY_CHECKED_EXPR_KIND_CALL or
+                 // LILY_CHECKED_EXPR_KIND_GROUPING or
+                 // LILY_CHECKED_EXPR_KIND_LAMBDA otherwise LilyCheckedDataType*
     const LilyAstExpr *ast_expr; // const LilyAstExpr* (&)
     union
     {

--- a/include/core/lily/checked/expr.h
+++ b/include/core/lily/checked/expr.h
@@ -62,12 +62,8 @@ typedef struct LilyCheckedExpr
     enum LilyCheckedExprKind kind;
     const Location *location; // const Location* (&)
                               // This is the result data type of the expression.
-    LilyCheckedDataType *
-      data_type; // LilyCheckedDataType* (&)
-                 // when is equal to LILY_CHECKED_EXPR_KIND_CALL or
-                 // LILY_CHECKED_EXPR_KIND_GROUPING or
-                 // LILY_CHECKED_EXPR_KIND_LAMBDA otherwise LilyCheckedDataType*
-    const LilyAstExpr *ast_expr; // const LilyAstExpr* (&)
+    LilyCheckedDataType *data_type; // LilyCheckedDataType*
+    const LilyAstExpr *ast_expr;    // const LilyAstExpr* (&)
     union
     {
         LilyCheckedExprArray array;

--- a/src/core/lily/analysis.c
+++ b/src/core/lily/analysis.c
@@ -1326,13 +1326,14 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
                     response.variable->is_moved = true;
                 }
 
-                data_type = response.variable->data_type;
+                data_type =
+                  ref__LilyCheckedDataType(response.variable->data_type);
 
                 return NEW_VARIANT(
                   LilyCheckedExpr,
                   call,
                   &expr->location,
-                  response.variable->data_type,
+                  data_type,
                   expr,
                   NEW(LilyCheckedExprCall,
                       LILY_CHECKED_EXPR_CALL_KIND_VARIABLE,
@@ -1354,7 +1355,8 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
                         scope, response.scope_container.scope_id));
                 }
 
-                data_type = response.constant->data_type;
+                data_type =
+                  ref__LilyCheckedDataType(response.constant->data_type);
 
                 return NEW_VARIANT(
                   LilyCheckedExpr,
@@ -1410,7 +1412,8 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
                         if (defined_data_type) {
                             update_data_type__LilyCheckedDataType(
                               response.fun_param->data_type, defined_data_type);
-                            data_type = response.fun_param->data_type;
+                            data_type = ref__LilyCheckedDataType(
+                              response.fun_param->data_type);
                         } else {
                             LilyCheckedScopeDecls *current_fun =
                               get_current_fun__LilyCheckedScope(scope);
@@ -1432,7 +1435,8 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
 
                         break;
                     default:
-                        data_type = response.fun_param->data_type;
+                        data_type = ref__LilyCheckedDataType(
+                          response.fun_param->data_type);
                 }
 
                 return NEW_VARIANT(
@@ -2235,7 +2239,8 @@ check_field_access__LilyAnalysis(LilyAnalysis *self,
                           LilyCheckedExpr,
                           call,
                           &path_item->location,
-                          field_response.record_field->data_type,
+                          ref__LilyCheckedDataType(
+                            field_response.record_field->data_type),
                           path_item,
                           NEW_VARIANT(
                             LilyCheckedExprCall,
@@ -2340,7 +2345,7 @@ check_field_access__LilyAnalysis(LilyAnalysis *self,
                       LilyCheckedExpr,
                       call,
                       &path->location,
-                      last->data_type,
+                      ref__LilyCheckedDataType(last->data_type),
                       path,
                       NEW_VARIANT(
                         LilyCheckedExprCall,
@@ -2709,9 +2714,10 @@ check_expr__LilyAnalysis(LilyAnalysis *self,
                                     switch (fun->fun.return_data_type->kind) {
                                         case LILY_CHECKED_DATA_TYPE_KIND_CONDITIONAL_COMPILER_CHOICE: {
                                             return_data_type =
-                                              get_return_data_type_of_conditional_compiler_choice(
-                                                fun->fun.return_data_type,
-                                                signature);
+                                              ref__LilyCheckedDataType(
+                                                get_return_data_type_of_conditional_compiler_choice(
+                                                  fun->fun.return_data_type,
+                                                  signature));
 
                                             if (!return_data_type) {
                                                 FAILED(
@@ -2724,17 +2730,19 @@ check_expr__LilyAnalysis(LilyAnalysis *self,
                                             break;
                                         }
                                         case LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC:
-                                            return_data_type = get__Vec(
-                                              signature,
-                                              get_id_of_param_from_compiler_generic__LilyCheckedDeclFun(
-                                                &fun->fun,
-                                                fun->fun.return_data_type
-                                                  ->compiler_generic.name));
+                                            return_data_type =
+                                              ref__LilyCheckedDataType(get__Vec(
+                                                signature,
+                                                get_id_of_param_from_compiler_generic__LilyCheckedDeclFun(
+                                                  &fun->fun,
+                                                  fun->fun.return_data_type
+                                                    ->compiler_generic.name)));
 
                                             break;
                                         default:
                                             return_data_type =
-                                              fun->fun.return_data_type;
+                                              ref__LilyCheckedDataType(
+                                                fun->fun.return_data_type);
                                     }
 
                                     LilyCheckedExpr *fun_call = NEW_VARIANT(
@@ -2885,7 +2893,8 @@ check_expr__LilyAnalysis(LilyAnalysis *self,
                       LilyCheckedExpr,
                       call,
                       &expr->location,
-                      builtin_signature->return_data_type,
+                      ref__LilyCheckedDataType(
+                        builtin_signature->return_data_type),
                       expr,
                       NEW_VARIANT(LilyCheckedExprCall,
                                   fun_builtin,
@@ -2970,7 +2979,7 @@ check_expr__LilyAnalysis(LilyAnalysis *self,
                       LilyCheckedExpr,
                       call,
                       &expr->location,
-                      sys_signature->return_data_type,
+                      ref__LilyCheckedDataType(sys_signature->return_data_type),
                       expr,
                       NEW_VARIANT(LilyCheckedExprCall,
                                   fun_sys,

--- a/src/core/lily/analysis.c
+++ b/src/core/lily/analysis.c
@@ -1326,14 +1326,13 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
                     response.variable->is_moved = true;
                 }
 
-                data_type =
-                  clone__LilyCheckedDataType(response.variable->data_type);
+                data_type = response.variable->data_type;
 
                 return NEW_VARIANT(
                   LilyCheckedExpr,
                   call,
                   &expr->location,
-                  data_type,
+                  response.variable->data_type,
                   expr,
                   NEW(LilyCheckedExprCall,
                       LILY_CHECKED_EXPR_CALL_KIND_VARIABLE,
@@ -1355,8 +1354,7 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
                         scope, response.scope_container.scope_id));
                 }
 
-                data_type =
-                  clone__LilyCheckedDataType(response.constant->data_type);
+                data_type = response.constant->data_type;
 
                 return NEW_VARIANT(
                   LilyCheckedExpr,
@@ -1370,19 +1368,19 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
                       (LilyCheckedAccessScope){
                         .id = response.scope_container.scope_id }));
             case LILY_CHECKED_SCOPE_RESPONSE_KIND_FUN_PARAM:
-                //if (response.fun_param->is_moved) {
-                //    emit__Diagnostic(
-                //      NEW_VARIANT(
-                //        Diagnostic,
-                //        simple_lily_error,
-                //        &self->package->file,
-                //        &expr->location,
-                //        NEW(LilyError, LILY_ERROR_KIND_VALUE_HAS_BEEN_MOVED),
-                //        NULL,
-                //        NULL,
-                //        NULL),
-                //      &self->package->count_error);
-                //}
+                // if (response.fun_param->is_moved) {
+                //     emit__Diagnostic(
+                //       NEW_VARIANT(
+                //         Diagnostic,
+                //         simple_lily_error,
+                //         &self->package->file,
+                //         &expr->location,
+                //         NEW(LilyError, LILY_ERROR_KIND_VALUE_HAS_BEEN_MOVED),
+                //         NULL,
+                //         NULL,
+                //         NULL),
+                //       &self->package->count_error);
+                // }
 
                 // Check if the variable is mutable.
                 if (must_mut) {
@@ -1412,8 +1410,7 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
                         if (defined_data_type) {
                             update_data_type__LilyCheckedDataType(
                               response.fun_param->data_type, defined_data_type);
-                            data_type = clone__LilyCheckedDataType(
-                              response.fun_param->data_type);
+                            data_type = response.fun_param->data_type;
                         } else {
                             LilyCheckedScopeDecls *current_fun =
                               get_current_fun__LilyCheckedScope(scope);
@@ -1435,8 +1432,7 @@ check_identifier_expr__LilyAnalysis(LilyAnalysis *self,
 
                         break;
                     default:
-                        data_type = clone__LilyCheckedDataType(
-                          response.fun_param->data_type);
+                        data_type = response.fun_param->data_type;
                 }
 
                 return NEW_VARIANT(
@@ -2239,8 +2235,7 @@ check_field_access__LilyAnalysis(LilyAnalysis *self,
                           LilyCheckedExpr,
                           call,
                           &path_item->location,
-                          clone__LilyCheckedDataType(
-                            field_response.record_field->data_type),
+                          field_response.record_field->data_type,
                           path_item,
                           NEW_VARIANT(
                             LilyCheckedExprCall,
@@ -2345,7 +2340,7 @@ check_field_access__LilyAnalysis(LilyAnalysis *self,
                       LilyCheckedExpr,
                       call,
                       &path->location,
-                      clone__LilyCheckedDataType(last->data_type),
+                      last->data_type,
                       path,
                       NEW_VARIANT(
                         LilyCheckedExprCall,
@@ -2713,17 +2708,12 @@ check_expr__LilyAnalysis(LilyAnalysis *self,
 
                                     switch (fun->fun.return_data_type->kind) {
                                         case LILY_CHECKED_DATA_TYPE_KIND_CONDITIONAL_COMPILER_CHOICE: {
-                                            LilyCheckedDataType
-                                              *inferred_return_data_type =
-                                                get_return_data_type_of_conditional_compiler_choice(
-                                                  fun->fun.return_data_type,
-                                                  signature);
+                                            return_data_type =
+                                              get_return_data_type_of_conditional_compiler_choice(
+                                                fun->fun.return_data_type,
+                                                signature);
 
-                                            if (inferred_return_data_type) {
-                                                return_data_type =
-                                                  clone__LilyCheckedDataType(
-                                                    inferred_return_data_type);
-                                            } else {
+                                            if (!return_data_type) {
                                                 FAILED(
                                                   "impossible to get a return "
                                                   "data type. NOTE: the "
@@ -2734,19 +2724,17 @@ check_expr__LilyAnalysis(LilyAnalysis *self,
                                             break;
                                         }
                                         case LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC:
-                                            return_data_type =
-                                              clone__LilyCheckedDataType(get__Vec(
-                                                signature,
-                                                get_id_of_param_from_compiler_generic__LilyCheckedDeclFun(
-                                                  &fun->fun,
-                                                  fun->fun.return_data_type
-                                                    ->compiler_generic.name)));
+                                            return_data_type = get__Vec(
+                                              signature,
+                                              get_id_of_param_from_compiler_generic__LilyCheckedDeclFun(
+                                                &fun->fun,
+                                                fun->fun.return_data_type
+                                                  ->compiler_generic.name));
 
                                             break;
                                         default:
                                             return_data_type =
-                                              clone__LilyCheckedDataType(
-                                                fun->fun.return_data_type);
+                                              fun->fun.return_data_type;
                                     }
 
                                     LilyCheckedExpr *fun_call = NEW_VARIANT(
@@ -2897,8 +2885,7 @@ check_expr__LilyAnalysis(LilyAnalysis *self,
                       LilyCheckedExpr,
                       call,
                       &expr->location,
-                      clone__LilyCheckedDataType(
-                        builtin_signature->return_data_type),
+                      builtin_signature->return_data_type,
                       expr,
                       NEW_VARIANT(LilyCheckedExprCall,
                                   fun_builtin,
@@ -2983,8 +2970,7 @@ check_expr__LilyAnalysis(LilyAnalysis *self,
                       LilyCheckedExpr,
                       call,
                       &expr->location,
-                      clone__LilyCheckedDataType(
-                        sys_signature->return_data_type),
+                      sys_signature->return_data_type,
                       expr,
                       NEW_VARIANT(LilyCheckedExprCall,
                                   fun_sys,
@@ -4404,10 +4390,23 @@ check_stmt__LilyAnalysis(LilyAnalysis *self,
 
                 // Check the data type of the return expression
                 if (fun_return_data_type) {
-                    if (fun_return_data_type->kind ==
-                        LILY_CHECKED_DATA_TYPE_KIND_UNKNOWN) {
+                    if ((fun_return_data_type->kind ==
+                           LILY_CHECKED_DATA_TYPE_KIND_UNKNOWN ||
+                         fun_return_data_type->kind ==
+                           LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC) &&
+                        expr->data_type->kind !=
+                          LILY_CHECKED_DATA_TYPE_KIND_UNKNOWN) {
                         update_data_type__LilyCheckedDataType(
                           fun_return_data_type, expr->data_type);
+                    } else if (
+                      expr->data_type->kind ==
+                        LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC &&
+                      (fun_return_data_type->kind !=
+                         LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC &&
+                       fun_return_data_type->kind !=
+                         LILY_CHECKED_DATA_TYPE_KIND_UNKNOWN)) {
+                        update_data_type__LilyCheckedDataType(
+                          expr->data_type, fun_return_data_type);
                     } else if (!eq__LilyCheckedDataType(fun_return_data_type,
                                                         expr->data_type)) {
                         FAILED("the data type doesn't match with the inferred "

--- a/src/core/lily/checked/data_type.c
+++ b/src/core/lily/checked/data_type.c
@@ -106,10 +106,6 @@ static VARIANT_DESTRUCTOR(LilyCheckedDataType,
                           compiler_choice,
                           LilyCheckedDataType *self);
 
-#define FREE_REC_DT(dt)                                \
-    if (!is_compiler_defined__LilyCheckedDataType(dt)) \
-        FREE(LilyCheckedDataType, dt);
-
 #ifdef ENV_DEBUG
 String *
 IMPL_FOR_DEBUG(to_string,
@@ -172,7 +168,7 @@ IMPL_FOR_DEBUG(to_string,
 
 DESTRUCTOR(LilyCheckedDataTypeArray, const LilyCheckedDataTypeArray *self)
 {
-    FREE_REC_DT(self->data_type);
+    FREE(LilyCheckedDataType, self->data_type);
 }
 
 #ifdef ENV_DEBUG
@@ -311,6 +307,7 @@ CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = kind;
     self->location = location;
+    self->ref_count = 0;
 
     return self;
 }
@@ -325,6 +322,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_ARRAY;
     self->location = location;
+    self->ref_count = 0;
     self->array = array;
 
     return self;
@@ -340,6 +338,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_BYTES;
     self->location = location;
+    self->ref_count = 0;
     self->bytes = bytes;
 
     return self;
@@ -355,6 +354,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_CUSTOM;
     self->location = location;
+    self->ref_count = 0;
     self->custom = custom;
 
     return self;
@@ -370,6 +370,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_EXCEPTION;
     self->location = location;
+    self->ref_count = 0;
     self->exception = exception;
 
     return self;
@@ -385,6 +386,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_LAMBDA;
     self->location = location;
+    self->ref_count = 0;
     self->lambda = lambda;
 
     return self;
@@ -400,6 +402,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_LIST;
     self->location = location;
+    self->ref_count = 0;
     self->list = list;
 
     return self;
@@ -415,6 +418,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_MUT;
     self->location = location;
+    self->ref_count = 0;
     self->mut = mut;
 
     return self;
@@ -430,6 +434,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_OPTIONAL;
     self->location = location;
+    self->ref_count = 0;
     self->optional = optional;
 
     return self;
@@ -445,6 +450,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_PTR;
     self->location = location;
+    self->ref_count = 0;
     self->ptr = ptr;
 
     return self;
@@ -460,6 +466,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_REF;
     self->location = location;
+    self->ref_count = 0;
     self->ref = ref;
 
     return self;
@@ -475,6 +482,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_STR;
     self->location = location;
+    self->ref_count = 0;
     self->str = str;
 
     return self;
@@ -490,6 +498,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_TRACE;
     self->location = location;
+    self->ref_count = 0;
     self->trace = trace;
 
     return self;
@@ -505,6 +514,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_TUPLE;
     self->location = location;
+    self->ref_count = 0;
     self->tuple = tuple;
 
     return self;
@@ -521,6 +531,7 @@ VARIANT_CONSTRUCTOR(
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_CONDITIONAL_COMPILER_CHOICE;
     self->location = location;
+    self->ref_count = 0;
     self->conditional_compiler_choice = conditional_compiler_choice;
 
     return self;
@@ -536,6 +547,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_COMPILER_CHOICE;
     self->location = location;
+    self->ref_count = 0;
     self->compiler_choice = compiler_choice;
 
     return self;
@@ -551,6 +563,7 @@ VARIANT_CONSTRUCTOR(LilyCheckedDataType *,
 
     self->kind = LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC;
     self->location = location;
+    self->ref_count = 0;
     self->compiler_generic = compiler_generic;
 
     return self;
@@ -1602,7 +1615,7 @@ VARIANT_DESTRUCTOR(LilyCheckedDataType, custom, LilyCheckedDataType *self)
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, exception, LilyCheckedDataType *self)
 {
-    FREE_REC_DT(self->exception);
+    FREE(LilyCheckedDataType, self->exception);
     lily_free(self);
 }
 
@@ -1614,48 +1627,44 @@ VARIANT_DESTRUCTOR(LilyCheckedDataType, lambda, LilyCheckedDataType *self)
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, list, LilyCheckedDataType *self)
 {
-    FREE_REC_DT(self->list);
+    FREE(LilyCheckedDataType, self->list);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, mut, LilyCheckedDataType *self)
 {
-    FREE_REC_DT(self->mut);
+    FREE(LilyCheckedDataType, self->mut);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, optional, LilyCheckedDataType *self)
 {
-    FREE_REC_DT(self->optional);
+    FREE(LilyCheckedDataType, self->optional);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, ptr, LilyCheckedDataType *self)
 {
-    FREE_REC_DT(self->ptr);
+    FREE(LilyCheckedDataType, self->ptr);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, ref, LilyCheckedDataType *self)
 {
-    FREE_REC_DT(self->ref);
+    FREE(LilyCheckedDataType, self->ref);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, trace, LilyCheckedDataType *self)
 {
-    FREE_REC_DT(self->trace);
+    FREE(LilyCheckedDataType, self->trace);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, tuple, LilyCheckedDataType *self)
 {
-    for (Usize i = 0; i < self->tuple->len; ++i) {
-        LilyCheckedDataType *data_type = get__Vec(self->tuple, i);
-
-        FREE_REC_DT(data_type);
-    }
-
+    FREE_BUFFER_ITEMS(
+      self->tuple->buffer, self->tuple->len, LilyCheckedDataType);
     FREE(Vec, self->tuple);
     lily_free(self);
 }
@@ -1679,6 +1688,12 @@ VARIANT_DESTRUCTOR(LilyCheckedDataType,
 
 DESTRUCTOR(LilyCheckedDataType, LilyCheckedDataType *self)
 {
+    if (self->ref_count > 0) {
+        --self->ref_count;
+
+        return;
+    }
+
     switch (self->kind) {
         case LILY_CHECKED_DATA_TYPE_KIND_ARRAY:
             FREE_VARIANT(LilyCheckedDataType, array, self);

--- a/src/core/lily/checked/data_type.c
+++ b/src/core/lily/checked/data_type.c
@@ -106,6 +106,10 @@ static VARIANT_DESTRUCTOR(LilyCheckedDataType,
                           compiler_choice,
                           LilyCheckedDataType *self);
 
+#define FREE_REC_DT(dt)                                \
+    if (!is_compiler_defined__LilyCheckedDataType(dt)) \
+        FREE(LilyCheckedDataType, dt);
+
 #ifdef ENV_DEBUG
 String *
 IMPL_FOR_DEBUG(to_string,
@@ -168,7 +172,7 @@ IMPL_FOR_DEBUG(to_string,
 
 DESTRUCTOR(LilyCheckedDataTypeArray, const LilyCheckedDataTypeArray *self)
 {
-    FREE(LilyCheckedDataType, self->data_type);
+    FREE_REC_DT(self->data_type);
 }
 
 #ifdef ENV_DEBUG
@@ -1598,7 +1602,7 @@ VARIANT_DESTRUCTOR(LilyCheckedDataType, custom, LilyCheckedDataType *self)
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, exception, LilyCheckedDataType *self)
 {
-    FREE(LilyCheckedDataType, self->exception);
+    FREE_REC_DT(self->exception);
     lily_free(self);
 }
 
@@ -1610,44 +1614,48 @@ VARIANT_DESTRUCTOR(LilyCheckedDataType, lambda, LilyCheckedDataType *self)
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, list, LilyCheckedDataType *self)
 {
-    FREE(LilyCheckedDataType, self->list);
+    FREE_REC_DT(self->list);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, mut, LilyCheckedDataType *self)
 {
-    FREE(LilyCheckedDataType, self->mut);
+    FREE_REC_DT(self->mut);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, optional, LilyCheckedDataType *self)
 {
-    FREE(LilyCheckedDataType, self->optional);
+    FREE_REC_DT(self->optional);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, ptr, LilyCheckedDataType *self)
 {
-    FREE(LilyCheckedDataType, self->ptr);
+    FREE_REC_DT(self->ptr);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, ref, LilyCheckedDataType *self)
 {
-    FREE(LilyCheckedDataType, self->ref);
+    FREE_REC_DT(self->ref);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, trace, LilyCheckedDataType *self)
 {
-    FREE(LilyCheckedDataType, self->trace);
+    FREE_REC_DT(self->trace);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedDataType, tuple, LilyCheckedDataType *self)
 {
-    FREE_BUFFER_ITEMS(
-      self->tuple->buffer, self->tuple->len, LilyCheckedDataType);
+    for (Usize i = 0; i < self->tuple->len; ++i) {
+        LilyCheckedDataType *data_type = get__Vec(self->tuple, i);
+
+        FREE_REC_DT(data_type);
+    }
+
     FREE(Vec, self->tuple);
     lily_free(self);
 }
@@ -1713,6 +1721,7 @@ DESTRUCTOR(LilyCheckedDataType, LilyCheckedDataType *self)
             FREE_VARIANT(LilyCheckedDataType, compiler_choice, self);
             break;
         case LILY_CHECKED_DATA_TYPE_KIND_COMPILER_GENERIC:
+            lily_free(self);
             break;
         default:
             lily_free(self);

--- a/src/core/lily/checked/expr.c
+++ b/src/core/lily/checked/expr.c
@@ -436,7 +436,12 @@ VARIANT_DESTRUCTOR(LilyCheckedExpr, binary, LilyCheckedExpr *self)
 VARIANT_DESTRUCTOR(LilyCheckedExpr, call, LilyCheckedExpr *self)
 {
     FREE(LilyCheckedExprCall, &self->call);
-    FREE(LilyCheckedDataType, self->data_type);
+
+    if (self->data_type->kind == LILY_CHECKED_DATA_TYPE_KIND_UNKNOWN &&
+        self->call.kind == LILY_CHECKED_EXPR_CALL_KIND_UNKNOWN) {
+        lily_free(self->data_type);
+    }
+
     lily_free(self);
 }
 
@@ -450,14 +455,12 @@ VARIANT_DESTRUCTOR(LilyCheckedExpr, cast, LilyCheckedExpr *self)
 VARIANT_DESTRUCTOR(LilyCheckedExpr, grouping, LilyCheckedExpr *self)
 {
     FREE(LilyCheckedExpr, self->grouping);
-    FREE(LilyCheckedDataType, self->data_type);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedExpr, lambda, LilyCheckedExpr *self)
 {
     FREE(LilyCheckedExprLambda, &self->lambda);
-    FREE(LilyCheckedDataType, self->data_type);
     lily_free(self);
 }
 

--- a/src/core/lily/checked/expr.c
+++ b/src/core/lily/checked/expr.c
@@ -436,12 +436,7 @@ VARIANT_DESTRUCTOR(LilyCheckedExpr, binary, LilyCheckedExpr *self)
 VARIANT_DESTRUCTOR(LilyCheckedExpr, call, LilyCheckedExpr *self)
 {
     FREE(LilyCheckedExprCall, &self->call);
-
-    if (self->data_type->kind == LILY_CHECKED_DATA_TYPE_KIND_UNKNOWN &&
-        self->call.kind == LILY_CHECKED_EXPR_CALL_KIND_UNKNOWN) {
-        lily_free(self->data_type);
-    }
-
+    FREE(LilyCheckedDataType, self->data_type);
     lily_free(self);
 }
 
@@ -455,12 +450,14 @@ VARIANT_DESTRUCTOR(LilyCheckedExpr, cast, LilyCheckedExpr *self)
 VARIANT_DESTRUCTOR(LilyCheckedExpr, grouping, LilyCheckedExpr *self)
 {
     FREE(LilyCheckedExpr, self->grouping);
+    FREE(LilyCheckedDataType, self->data_type);
     lily_free(self);
 }
 
 VARIANT_DESTRUCTOR(LilyCheckedExpr, lambda, LilyCheckedExpr *self)
 {
     FREE(LilyCheckedExprLambda, &self->lambda);
+    FREE(LilyCheckedDataType, self->data_type);
     lily_free(self);
 }
 


### PR DESCRIPTION
This correction will fix this kind of bug:

Fixed a bug in the analysis of this function:
```
fun add(x) =
  if true do
    return x;
  elif x do
    return x;
  else
    return false;
  end
end
```

The signature should be: `fun(Bool) Bool`